### PR TITLE
Locked cards until dismiss + public function for dismiss from CardContainer

### DIFF
--- a/AndTinder/src/main/java/com/andtinder/view/CardContainer.java
+++ b/AndTinder/src/main/java/com/andtinder/view/CardContainer.java
@@ -476,7 +476,7 @@ public class CardContainer extends AdapterView<ListAdapter> {
                 public void run() {
                     locked = false; // Unlock swipe
                 }
-            }, duration);
+            }, duration + 200);
 
             mTopCard = getChildAt(getChildCount() - 2);
             CardModel cardModel = (CardModel) getAdapter().getItem(0);


### PR DESCRIPTION
Sometimes when dismiss a card, it remains in front of the view (even when it isn't really there). I created a "locked" boolean var for avoid dismissing floating cards and it seems to solves the problem.

Also I created a public function for dismiss cards directly from the CardContainer view. Example of use:

```
findViewById(R.id.like).setOnClickListener(new View.OnClickListener() {
    @Override
    public void onClick(View v) {
        if (count < RESULTS_PER_PAGE)
            mCardContainer.leave(1000, 45);
    }
});
```